### PR TITLE
APIV1Ping return 'nil' change to []byte 'Pong'

### DIFF
--- a/internal/restinterface/internalhandler/internalhandler.go
+++ b/internal/restinterface/internalhandler/internalhandler.go
@@ -134,7 +134,9 @@ func (h *Handler) SetCertificateFilePath(path string) {
 
 // APIV1Ping handles ping request from remote orchestration
 func (h *Handler) APIV1Ping(w http.ResponseWriter, r *http.Request) {
-	h.helper.Response(w, nil, http.StatusOK)
+	var responseBytes []byte
+	responseBytes = []byte("Pong")
+	h.helper.Response(w, responseBytes, http.StatusOK)
 }
 
 // APIV1ServicemgrServicesPost handles service execution request from remote orchestration


### PR DESCRIPTION
# Description

Sending `Pong` message in response to the `api/v1/ping` request.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Call `ping` request by curl and check the response message `Pong`.
```sh
curl localhost:56002/api/v1/ping
```

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64 
* Toolchain: Docker v20.10 & Go v1.16
* Edge Orchestration Release: v1.1.x

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
